### PR TITLE
Delete the download link from the default template

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,10 +21,6 @@
           <h1 id="project_title">Bacchus</h1>
           <h2 id="project_tagline">Bacchus</h2>
 
-            <section id="downloads">
-              <a class="zip_download_link" href="https://github.com/ikerito7/Bacchus-R1/zipball/master">Download this project as a .zip file</a>
-              <a class="tar_download_link" href="https://github.com/ikerito7/Bacchus-R1/tarball/master">Download this project as a tar.gz file</a>
-            </section>
         </header>
     </div>
 


### PR DESCRIPTION
The default template from GitHub is intended for publishing the source code of the project. So it has two downloading links there. 
Removing it since it's irrelevant.

I think you can merge this pull request on the website directly. So you guys don't need to bother with ```git merge``` at the moment.

btw, for those who don't know me, I am Tony, taught some of you basic Git that day :)